### PR TITLE
➕ Replace `mathieutu/exporter` dependency by `tightenco/collect`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">= 7.1.0",
-        "mathieutu/exporter": "^2.0"
+        "tightenco/collect": "^5.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",


### PR DESCRIPTION
As `mathieutu/exporter` is not used in the library which only depends on `tightenco/collect`.