### PR TITLE
✨ Allow to inject options during `Transformer` instanciation

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -4,11 +4,6 @@ namespace MathieuTu\Transformer;
 
 trait Helpers
 {
-    protected function with(string $transformerClass, $paths = null): Transformer
-    {
-        return new $transformerClass($this->get($paths), $paths);
-    }
-
     /**
      * @param string[]|string $path
      * @param string $nestedIn

--- a/src/Transformations.php
+++ b/src/Transformations.php
@@ -4,11 +4,6 @@ namespace MathieuTu\Transformer;
 
 trait Transformations
 {
-    public static function transform($dataToTransform, $key = null)
-    {
-        return (new static($dataToTransform, $key))->serialize();
-    }
-
     public function serialize()
     {
         $serialized = $this->prepareTransformation();

--- a/src/Transformer.php
+++ b/src/Transformer.php
@@ -11,13 +11,19 @@ abstract class Transformer implements JsonSerializable, Arrayable, Jsonable, Ser
 
     private $key;
     private $dataToTransform;
+    protected $options;
 
-    public function __construct($dataToTransform, $key = null)
+    public static function transform($dataToTransform, $key = null, array $options = [])
+    {
+        return (new static($dataToTransform, $key, $options))->serialize();
+    }
+
+    public function __construct($dataToTransform, $key = null, array $options = [])
     {
         $this->dataToTransform = $dataToTransform;
         $this->key = $key;
+        $this->options = $options;
     }
-
 
     public function prepareTransformation()
     {
@@ -37,6 +43,16 @@ abstract class Transformer implements JsonSerializable, Arrayable, Jsonable, Ser
         }
 
         return $merged->parseNested();
+    }
+
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    protected function with(string $transformerClass, $paths = null): Transformer
+    {
+        return new $transformerClass($this->get($paths), $paths, $this->options);
     }
 
     abstract protected function map();

--- a/tests/TransformerTest.php
+++ b/tests/TransformerTest.php
@@ -103,4 +103,27 @@ class TransformerTest extends TestCase
             $transformer::transform(['Iwazaru' => 134, 'cl' => 212])
         );
     }
+
+    /**
+     * @dataProvider transformerOptions
+     */
+    public function testTransformerCanAccessOptions(array $options)
+    {
+        $transformer = new class([], '', $options) extends Transformer {
+            protected function map()
+            {
+            }
+        };
+
+        $this->assertSame($options, $transformer->getOptions());
+    }
+
+    public function transformerOptions(): array
+    {
+        return [
+            [[]],
+            [['foor' => 'bar']],
+            [['foor' => 'bar', 'john' => 'doe']],
+        ];
+    }
 }


### PR DESCRIPTION
Options can be use to setup internal informations about the current code execution.

It will allow to make conditional transformation in a transformer.